### PR TITLE
add sendTx output info for iwallet

### DIFF
--- a/core/global/tx_db.go
+++ b/core/global/tx_db.go
@@ -3,7 +3,6 @@ package global
 import (
 	"errors"
 	"fmt"
-
 	"github.com/iost-official/go-iost/core/tx"
 	"github.com/iost-official/go-iost/db/kv"
 )

--- a/iwallet/compile.go
+++ b/iwallet/compile.go
@@ -200,6 +200,9 @@ var compileCmd = &cobra.Command{
 			}
 			fmt.Println("iost node:receive your tx!")
 			fmt.Println("the transaction hash is:", saveBytes(txHash))
+			if checkResult {
+				checkTransaction(txHash)
+			}
 			return
 		}
 

--- a/iwallet/publish.go
+++ b/iwallet/publish.go
@@ -108,6 +108,9 @@ var publishCmd = &cobra.Command{
 		}
 		fmt.Println("iost node:receive your tx!")
 		fmt.Println("the transaction hash is:", saveBytes(txHash))
+		if checkResult {
+			checkTransaction(txHash)
+		}
 	},
 }
 

--- a/iwallet/root.go
+++ b/iwallet/root.go
@@ -40,6 +40,9 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVarP(&dest, "dest", "d", "default", "Set destination of output file")
 	rootCmd.PersistentFlags().StringVarP(&server, "server", "s", "localhost:30002", "Set server of this client")
+	rootCmd.PersistentFlags().BoolVarP(&checkResult, "checkResult", "c", true, "Check publish/call status after sending to chain")
+	rootCmd.PersistentFlags().Float32VarP(&checkResultDelay, "checkResultDelay", "", 1, "RPC checking will occur at [checkResultDelay] seconds after sending to chain.")
+	rootCmd.PersistentFlags().Int32VarP(&checkResultMaxRetry, "checkResultMaxRetry", "", 60, "Max times to call grpc to check tx status")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/iwallet/utils.go
+++ b/iwallet/utils.go
@@ -1,6 +1,10 @@
 package iwallet
 
 import (
+	"context"
+	"github.com/iost-official/go-iost/core/tx"
+	"github.com/iost-official/go-iost/rpc"
+	"google.golang.org/grpc"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -59,4 +63,19 @@ func getSignAlgo(algo string) crypto.Algorithm {
 	default:
 		return crypto.Ed25519
 	}
+}
+
+func getTxReceiptByTxHash(server string, txHashStr string) (*tx.TxReceiptRaw, error) {
+	conn, err := grpc.Dial(server, grpc.WithInsecure())
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	client := rpc.NewApisClient(conn)
+	resp, err := client.GetTxReceiptByTxHash(context.Background(), &rpc.HashReq{Hash: txHashStr})
+	if err != nil {
+		return nil, err
+	}
+	//ilog.Debugf("getTxReceiptByTxHash(%v): %v", txHashStr, resp.TxReceiptRaw)
+	return resp.TxReceiptRaw, nil
 }


### PR DESCRIPTION
在 iwallet 所有的 sendTx 之后，加入了调用结果输出。
* 成功时输出：
```
send tx done. gas used:  303
```
* 失败时输出：
```
send tx failed:  balance not enough
full error information:  txHash:"*\311\235UGbR\251\375>V\243y/\336\203\023\343\332\262\266Y\304\247^\"\325\364\364j\013\234" gasUsage:303 status:<code:4 message:"balance not enough" >
```
