### PR TITLE
Zzhang/feature/gas shortcut

### DIFF
--- a/consensus/genesis/genesis.go
+++ b/consensus/genesis/genesis.go
@@ -142,10 +142,10 @@ func genGenesisTx(gConf *common.GenesisConfig) (*tx.Tx, *account.KeyPair, error)
 	}
 	acts = append(acts, tx.NewAction("system.iost", "InitSetCode", fmt.Sprintf(`["%v", "%v"]`, "ram.iost", code.B64Encode())))
 	acts = append(acts, tx.NewAction("ram.iost", "initAdmin", fmt.Sprintf(`["%v"]`, adminInfo.ID)))
-	var initialTotal int64 = 128 * 1024 * 1024 * 1024        // 128GB at first
-	var increaseInterval int64 = 24 * 3600                   // increase every day
-	var increaseAmount int64 = 64 * 1024 * 1024 * 1024 / 365 // 64GB per year
-	var reserveRAM = initialTotal * 3 / 10                   // reserve for foundation
+	var initialTotal int64 = 128 * 1024 * 1024 * 1024                           // 128GB at first
+	var increaseInterval int64 = 10 * 60                                        // increase every 10 mins
+	var increaseAmount int64 = 10 * (64 * 1024 * 1024 * 1024) / (365 * 24 * 60) // 64GB per year
+	var reserveRAM = initialTotal * 3 / 10                                      // reserve for foundation
 	acts = append(acts, tx.NewAction("ram.iost", "issue", fmt.Sprintf(`[%v, %v, %v, %v]`, initialTotal, increaseInterval, increaseAmount, reserveRAM)))
 
 	adminInitialRAM := 100000

--- a/contract/ram.js
+++ b/contract/ram.js
@@ -142,16 +142,15 @@ class RAMContract {
     }
 
     _checkIssue() {
-        const t = block.time;
-        const nextUpdateTime = this._get("lastUpdateBlockTime") + this._get("increaseInterval") * 1000 * 1000 * 1000;
-        if (t < nextUpdateTime) {
-            return;
+        const increaseInterval = this._get("increaseInterval");
+        const slotNum = Math.floor(block.time/1e9/increaseInterval) - Math.floor(this._get("lastUpdateBlockTime")/1e9/increaseInterval);
+        if (slotNum > 0) {
+            const increaseAmount = this._get("increaseAmount") * slotNum;
+            const data = [this._getTokenName(), blockchain.contractName(), increaseAmount.toString()];
+            blockchain.callWithAuth("token.iost", "issue", JSON.stringify(data));
+            this._put("lastUpdateBlockTime", block.time);
+            this._changeLeftSpace(increaseAmount);
         }
-        const increaseAmount = this._get("increaseAmount");
-        const data = [this._getTokenName(), blockchain.contractName(), increaseAmount.toString()];
-        blockchain.callWithAuth("token.iost", "issue", JSON.stringify(data));
-        this._put("lastUpdateBlockTime", t);
-        this._changeLeftSpace(increaseAmount);
     }
 
     buy(payer, account, amount) {

--- a/iwallet/account.go
+++ b/iwallet/account.go
@@ -121,7 +121,7 @@ func viewAccount(name string) {
 				return
 			}
 			for _, f := range files {
-				fsk, err := readFile(f)
+				fsk, err := loadKey(f)
 				if err != nil {
 					fmt.Println("read file failed: ", err)
 					continue

--- a/iwallet/sdk.go
+++ b/iwallet/sdk.go
@@ -303,7 +303,7 @@ func (s *SDK) loadAccount() error {
 		return fmt.Errorf("you must provide account name")
 	}
 	kpPath := fmt.Sprintf("%s/%s_%s", dir, s.accountName, s.getSignAlgoName())
-	fsk, err := readFile(kpPath)
+	fsk, err := loadKey(kpPath)
 	if err != nil {
 		return fmt.Errorf("read file failed: %v", err)
 	}
@@ -342,7 +342,7 @@ func (s *SDK) saveAccount(name string, kp *account.KeyPair) error {
 		return err
 	}
 
-	secFile, err := os.Create(fileName)
+	secFile, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0400)
 	if err != nil {
 		return err
 	}
@@ -415,7 +415,9 @@ func (s *SDK) CreateNewAccount(newID string, newKp *account.KeyPair, initialGasP
 	if initialRAM > 0 {
 		acts = append(acts, NewAction("ram.iost", "buy", fmt.Sprintf(`["%v", "%v", %v]`, s.accountName, newID, initialRAM)))
 	}
-	acts = append(acts, NewAction("gas.iost", "pledge", fmt.Sprintf(`["%v", "%v", "%v"]`, s.accountName, newID, initialGasPledge)))
+	if initialGasPledge > 0 {
+		acts = append(acts, NewAction("gas.iost", "pledge", fmt.Sprintf(`["%v", "%v", "%v"]`, s.accountName, newID, initialGasPledge)))
+	}
 	if initialCoins > 0 {
 		acts = append(acts, NewAction("token.iost", "transfer", fmt.Sprintf(`["iost", "%v", "%v", "%v", ""]`, s.accountName, newID, initialCoins)))
 	}

--- a/iwallet/utils.go
+++ b/iwallet/utils.go
@@ -1,6 +1,7 @@
 package iwallet
 
 import (
+	"fmt"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	"github.com/iost-official/go-iost/common"
@@ -38,12 +39,32 @@ func saveTo(Dist string, file []byte) error {
 }
 */
 
-func readFile(src string) ([]byte, error) {
+func loadKey(src string) ([]byte, error) {
 	fi, err := os.Open(src)
+	defer fi.Close()
 	if err != nil {
 		return nil, err
 	}
+	fileinfo, err := fi.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if fileinfo.Mode() != 0400 {
+		return nil, fmt.Errorf("private key file should have read only permission. try:\n chmod 0400 %v", src)
+	}
+	fd, err := ioutil.ReadAll(fi)
+	if err != nil {
+		return nil, err
+	}
+	return fd, nil
+}
+
+func readFile(src string) ([]byte, error) {
+	fi, err := os.Open(src)
 	defer fi.Close()
+	if err != nil {
+		return nil, err
+	}
 	fd, err := ioutil.ReadAll(fi)
 	if err != nil {
 		return nil, err

--- a/rpc/api_service.go
+++ b/rpc/api_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/iost-official/go-iost/vm"
 	"reflect"
 	"sort"
 	"time"
@@ -348,12 +349,12 @@ func (as *APIService) SendTransaction(ctx context.Context, req *rpcpb.Transactio
 		}
 	}
 	dbVisitor := as.getStateDBVisitor(true)
-	gasLimit := &common.Fixed{Value: t.GasLimit, Decimal: 2}
-	gas := dbVisitor.TotalGasAtTime(t.Publisher, as.bc.Head().Head.Time)
-	if gas.LessThan(gasLimit) {
-		return nil, fmt.Errorf("invalid gas of user %v has %v < %v", t.Publisher, gas.ToString(), gasLimit.ToString())
+	currentGas := dbVisitor.TotalGasAtTime(t.Publisher, as.bc.Head().Head.Time)
+	err := vm.CheckTxGasLimitValid(t, currentGas, dbVisitor)
+	if err != nil {
+		return nil, err
 	}
-	err := as.txpool.AddTx(t)
+	err = as.txpool.AddTx(t)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/gas_test.go
+++ b/test/integration/gas_test.go
@@ -290,7 +290,7 @@ func TestGas_unpledgeTooMuch(t *testing.T) {
 		So(err, ShouldBeNil)
 		delta1 := int64(1)
 		timePass(h, delta1)
-		unpledgeAmount := (pledgeAmount - native.GasMinPledgeInIOST) + int64(1)
+		unpledgeAmount := (pledgeAmount - int64(native.GasMinPledgeOfUser.ToFloat())) + int64(1)
 		_, _, err = e.LoadAndCall(h, code, "unpledge", testAcc, testAcc, toString(unpledgeAmount))
 		So(err, ShouldNotBeNil)
 	})

--- a/test/integration/ram_test.go
+++ b/test/integration/ram_test.go
@@ -42,8 +42,8 @@ func TestRAM(t *testing.T) {
 	}
 
 	var initialTotal int64 = 128 * 1024 * 1024 * 1024
-	var increaseInterval int64 = 24 * 3600
-	var increaseAmount int64 = 64 * 1024 * 1024 * 1024 / 365
+	var increaseInterval int64 = 10 * 60                   // increase every 10 mins
+	var increaseAmount int64 = 10 * (64*1024*1024*1024) / (365 * 24 * 60) // 64GB per year
 	r, err = s.Call(contractName, "issue", array2json([]interface{}{initialTotal, increaseInterval, increaseAmount, 0}), admin.ID, admin)
 	if err != nil || r.Status.Code != tx.StatusCode(tx.Success) {
 		panic("call failed " + err.Error() + " " + r.String())
@@ -77,14 +77,14 @@ func TestRAM(t *testing.T) {
 			})
 			Convey("when buying triggers increasing total ram", func() {
 				head := s.Head
-				head.Time = head.Time + increaseInterval*1000*1000*1000
+				head.Time = head.Time + 144 * increaseInterval*1000*1000*1000
 				s.SetBlockHead(head)
 				ramAvailableBefore := s.Visitor.TokenBalance("ram", contractName)
 				r, err := s.Call(contractName, "buy", array2json([]interface{}{kp.ID, kp.ID, buyAmount}), kp.ID, kp)
 				So(err, ShouldEqual, nil)
 				So(r.Status.Message, ShouldEqual, "")
 				ramAvailableAfter := s.Visitor.TokenBalance("ram", contractName)
-				So(ramAvailableAfter, ShouldEqual, ramAvailableBefore+increaseAmount-buyAmount)
+				So(ramAvailableAfter, ShouldEqual, ramAvailableBefore+ 144 * increaseAmount-buyAmount)
 			})
 			Convey("user can buy for others", func() {
 				other := testID[4]

--- a/verifier/simulator.go
+++ b/verifier/simulator.go
@@ -80,6 +80,11 @@ func (s *Simulator) SetGas(id string, i int64) {
 	s.Visitor.Commit()
 }
 
+// GetGas ...
+func (s *Simulator) GetGas(id string) int64 {
+	return s.Visitor.TotalGasAtTime(id, s.Head.Time).Value / 100
+}
+
 // SetRAM to id
 func (s *Simulator) SetRAM(id string, r int64) {
 	s.Visitor.SetTokenBalance("ram", id, r)
@@ -200,7 +205,6 @@ func (s *Simulator) CallTx(trx *tx.Tx, publisher string, auth *account.KeyPair) 
 	if err != nil {
 		return &tx.TxReceipt{}, err
 	}
-
 	r, err := isolator.PayCost()
 	if err != nil {
 		return nil, err

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -191,7 +191,7 @@ L:
 		var r *tx.TxReceipt
 		r, err = isolator.Run()
 		if err != nil {
-			ilog.Errorf("isolator run error %v", err)
+			ilog.Errorf("isolator run error %v %v", t.String(), err)
 			provider.Drop(t, err)
 			continue L
 		}
@@ -205,7 +205,12 @@ L:
 			break L
 		}
 		//ilog.Debugf("exec tx %v success", common.Base58Encode(t.Hash()))
-		r, _ = isolator.PayCost()
+		r, err = isolator.PayCost()
+		if err != nil {
+			ilog.Errorf("pay cost err %v %v", t.String(), err)
+			provider.Drop(t, err)
+			continue L
+		}
 		isolator.Commit()
 		blk.Txs = append(blk.Txs, t)
 		blk.Receipts = append(blk.Receipts, r)

--- a/vm/host/errors.go
+++ b/vm/host/errors.go
@@ -10,7 +10,7 @@ var (
 	ErrPermissionLost   = errors.New("transaction has no permission")
 	ErrInvalidData      = errors.New("invalid data")
 	ErrInvalidAmount    = errors.New("invalid amount")
-	ErrGasLimitExceeded = errors.New("out of gas")
+	ErrOutOfGas         = errors.New("out of gas")
 
 	ErrContractNotFound   = errors.New("contract not exists")
 	ErrContractExists     = errors.New("contract exists")

--- a/vm/host/teller.go
+++ b/vm/host/teller.go
@@ -123,7 +123,7 @@ func (t *Teller) DoPay(witness string, gasRatio int64) (payedGas *common.Fixed, 
 		if !gas.IsZero() {
 			err := t.h.CostGas(payer, gas)
 			if err != nil {
-				ilog.Fatalf("pay gas cost failed: %v %v %v", err, payer, gas)
+				return nil, fmt.Errorf("pay gas cost failed: %v %v %v", err, payer, gas)
 			}
 			// reward 15% gas to account referrer
 			if !t.h.IsContract(payer) {
@@ -137,6 +137,7 @@ func (t *Teller) DoPay(witness string, gasRatio int64) (payedGas *common.Fixed, 
 				}
 			}
 		}
+
 		if payer == t.h.Context().Value("publisher").(string) {
 			payedGas = gas
 		}

--- a/vm/isolator.go
+++ b/vm/isolator.go
@@ -224,7 +224,7 @@ func (i *Isolator) Run() (*tx.TxReceipt, error) { // nolint
 		actionCost.AddAssign(contract.NewCost(0, int64(len(ret)), 0))
 		if (status.Code == tx.ErrorRuntime && status.Message == "out of gas") ||
 			(vmGasLimit < actionCost.ToGas()) ||
-			(!i.genesisMode && i.h.TotalGas(i.t.Publisher).Value/i.t.GasRatio < i.h.GasPayed()+vmGasLimit) {
+			(!i.genesisMode && !i.blockBaseMode && i.h.TotalGas(i.t.Publisher).Value/i.t.GasRatio < i.h.GasPayed()+vmGasLimit) {
 			ilog.Errorf("out of gas vmGasLimit %v actionCost %v totalGas %v gasPayed %v", vmGasLimit, actionCost.ToGas(), i.h.TotalGas(i.t.Publisher).ToString(), i.h.GasPayed())
 			status.Code = tx.ErrorRuntime
 			status.Message = "out of gas"

--- a/vm/isolator.go
+++ b/vm/isolator.go
@@ -72,10 +72,9 @@ func (i *Isolator) PrepareTx(t *tx.Tx, limit time.Duration) error {
 			return fmt.Errorf("gas limit should be larger")
 		}
 		gas := i.h.TotalGas(i.publisherID)
-		gasLimit := &common.Fixed{Value: t.GasLimit, Decimal: 2}
-		if gas.LessThan(gasLimit) {
-			ilog.Infof("publisher's gas balance is less than gas limit: publisher %v current gas:%v, gas limit:%v\n", i.publisherID, gas.ToString(), gasLimit.ToString())
-			return fmt.Errorf("%v gas less than limit %v < %v", i.publisherID, gas.ToString(), gasLimit.ToString())
+		err = CheckTxGasLimitValid(t, gas, i.h.DB())
+		if err != nil {
+			return err
 		}
 	}
 	loadTxInfo(i.h, t, i.publisherID)
@@ -175,7 +174,7 @@ func (i *Isolator) runAction(action tx.Action) (cost contract.Cost, status *tx.S
 }
 
 // Run actions in tx
-func (i *Isolator) Run() (*tx.TxReceipt, error) { // nolinty
+func (i *Isolator) Run() (*tx.TxReceipt, error) { // nolint
 	vmGasLimit := i.t.GasLimit/i.t.GasRatio - i.h.GasPayed()
 	if vmGasLimit <= 0 {
 		ilog.Fatalf("vmGasLimit < 0. It should not happen. %v / %v < %v", i.t.GasLimit, i.t.GasRatio, i.h.GasPayed())
@@ -217,33 +216,27 @@ func (i *Isolator) Run() (*tx.TxReceipt, error) { // nolinty
 		ilog.Debugf("used cost %v\n", actionCost)
 		ilog.Debugf("status %v\n", status)
 		ilog.Debugf("return value: %v\n", ret)
-
 		if err != nil {
 			return nil, err
 		}
 
 		i.tr.Status = status
-		if (status.Code == tx.ErrorRuntime && status.Message == "out of gas") || (status.Code == tx.ErrorTimeout) {
+		actionCost.AddAssign(contract.NewCost(0, int64(len(ret)), 0))
+		if (status.Code == tx.ErrorRuntime && status.Message == "out of gas") ||
+			(vmGasLimit < actionCost.ToGas()) ||
+			(!i.genesisMode && i.h.TotalGas(i.t.Publisher).Value/i.t.GasRatio < i.h.GasPayed()+vmGasLimit) {
+			ilog.Errorf("out of gas vmGasLimit %v actionCost %v totalGas %v gasPayed %v", vmGasLimit, actionCost.ToGas(), i.h.TotalGas(i.t.Publisher).ToString(), i.h.GasPayed())
+			status.Code = tx.ErrorRuntime
+			status.Message = "out of gas"
 			actionCost.CPU = vmGasLimit
 			actionCost.Net = 0
-		}
-		actionCost.AddAssign(contract.NewCost(0, int64(len(ret)), 0))
-		if actionCost.ToGas() > vmGasLimit {
-			//ilog.Errorf("vm limit gas exceed %v(%v) > %v", actionCost.ToGas(), actionCost, vmGasLimit)
-			i.tr.Status = &tx.Status{Code: tx.ErrorRuntime, Message: host.ErrGasLimitExceeded.Error()}
+			ret = ""
+		} else if status.Code == tx.ErrorTimeout {
 			actionCost.CPU = vmGasLimit
 			actionCost.Net = 0
 			ret = ""
 		}
 
-		if status.Code == 0 {
-			for k, v := range i.h.Costs() {
-				i.tr.RAMUsage[k] = v.Data
-			}
-		}
-
-		vmGasLimit -= actionCost.ToGas()
-		i.h.Context().GSet("gas_limit", vmGasLimit)
 		i.h.PayCost(actionCost, i.publisherID)
 
 		if status.Code != tx.Success {
@@ -253,10 +246,15 @@ func (i *Isolator) Run() (*tx.TxReceipt, error) { // nolinty
 			i.h.ClearRAMCosts()
 			i.tr.RAMUsage = make(map[string]int64)
 			break
-		} else {
-			i.tr.Receipts = append(i.tr.Receipts, receipts...)
 		}
+
+		i.tr.Receipts = append(i.tr.Receipts, receipts...)
 		i.tr.Returns = append(i.tr.Returns, ret)
+		vmGasLimit -= actionCost.ToGas()
+		i.h.Context().GSet("gas_limit", vmGasLimit)
+	}
+	for k, v := range i.h.Costs() {
+		i.tr.RAMUsage[k] = v.Data
 	}
 
 	return i.tr, nil
@@ -271,13 +269,14 @@ func (i *Isolator) PayCost() (*tx.TxReceipt, error) {
 	if err != nil {
 		ilog.Errorf("DoPay failed, rollback %v", err)
 		i.h.DB().Rollback()
+
 		i.h.ClearRAMCosts()
 		i.tr.RAMUsage = make(map[string]int64)
 		i.tr.Status.Code = tx.ErrorBalanceNotEnough
 		i.tr.Status.Message = "balance not enough after executing actions: " + err.Error()
 		payedGas, err = i.h.DoPay(i.h.Context().Value("witness").(string), i.t.GasRatio)
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 	}
 	i.tr.GasUsage = payedGas.Value

--- a/vm/monitor.go
+++ b/vm/monitor.go
@@ -51,7 +51,7 @@ func (m *Monitor) prepareContract(h *host.Host, contractName, api, jarg string) 
 		return nil, nil, nil, fmt.Errorf("abi %s not found", api)
 	}
 
-	args, err = unmarshalArgs(abi, jarg)
+	args, err = UnmarshalArgs(abi, jarg)
 
 	return
 }
@@ -59,9 +59,7 @@ func (m *Monitor) prepareContract(h *host.Host, contractName, api, jarg string) 
 // Call ...
 // nolint
 func (m *Monitor) Call(h *host.Host, contractName, api string, jarg string) (rtn []interface{}, cost contract.Cost, err error) {
-
 	c, abi, args, err := m.prepareContract(h, contractName, api, jarg)
-
 	if err != nil {
 		return nil, host.Costs["GetCost"], fmt.Errorf("prepare contract: %v", err)
 	}
@@ -231,7 +229,8 @@ func Factory(lang string) VM {
 	return nil
 }
 
-func unmarshalArgs(abi *contract.ABI, data string) ([]interface{}, error) {
+// UnmarshalArgs convert action data to args according to abi
+func UnmarshalArgs(abi *contract.ABI, data string) ([]interface{}, error) {
 	if strings.HasSuffix(data, ",]") {
 		data = data[:len(data)-2] + "]"
 	}

--- a/vm/native/native.go
+++ b/vm/native/native.go
@@ -1,8 +1,6 @@
 package native
 
 import (
-	"errors"
-
 	"github.com/iost-official/go-iost/core/contract"
 	"github.com/iost-official/go-iost/ilog"
 	"github.com/iost-official/go-iost/vm/host"
@@ -81,7 +79,6 @@ func (i *Impl) LoadAndCall(h *host.Host, con *contract.Contract, api string, arg
 		a  *abi
 		ok bool
 	)
-
 	switch con.ID {
 	case "system.iost":
 		a, ok = systemABIs.Get(api)
@@ -93,13 +90,18 @@ func (i *Impl) LoadAndCall(h *host.Host, con *contract.Contract, api string, arg
 		a, ok = tokenABIs.Get(api)
 	case "token721.iost":
 		a, ok = token721ABIs.Get(api)
+	default:
+		ilog.Fatalf("invalid contract name: %v, please check `Monitor.prepareContract`", con.ID)
 	}
 	if !ok {
-		ilog.Fatal("error", con.ID, api, systemABIs)
-		return nil, host.CommonErrorCost(1), errors.New("unknown api name")
+		ilog.Fatalf("invalid api name: %v of %v, please check `Monitor.prepareContract`", api, con.ID)
 	}
 
-	return a.do(h, args...)
+	rtn, cost, err = a.do(h, args...)
+	if cost.ToGas() > h.Context().GValue("gas_limit").(int64) {
+		err = host.ErrOutOfGas
+	}
+	return
 }
 
 // CheckCost check if cost exceed gas_limit

--- a/vm/native/token.go
+++ b/vm/native/token.go
@@ -253,7 +253,7 @@ var (
 				}
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// check auth
@@ -263,7 +263,7 @@ var (
 				return nil, cost, host.ErrPermissionLost
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// check exists
@@ -325,7 +325,7 @@ var (
 			totalSupply, cost0 := h.MapGet(TokenInfoMapPrefix+tokenSym, TotalSupplyMapField)
 			cost.AddAssign(cost0)
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// check auth
@@ -335,7 +335,7 @@ var (
 				return nil, cost, host.ErrPermissionLost
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// get amount by fixed point number
@@ -353,7 +353,7 @@ var (
 				return nil, cost, errors.New("supply too much")
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// set supply, set balance
@@ -424,7 +424,7 @@ var (
 				return nil, cost, host.ErrTokenNoTransfer
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// check auth
@@ -434,7 +434,7 @@ var (
 				return nil, cost, host.ErrPermissionLost
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// get amount by fixed point number
@@ -447,7 +447,7 @@ var (
 				return nil, cost, host.ErrInvalidAmount
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// set balance
@@ -470,7 +470,7 @@ var (
 				return nil, cost, fmt.Errorf("balance not enough %v < %v", fBalanceFixed.ToString(), amountFixed.ToString())
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			fbalance -= amount
@@ -521,7 +521,7 @@ var (
 				return nil, cost, host.ErrTokenNoTransfer
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// check auth
@@ -531,7 +531,7 @@ var (
 				return nil, cost, host.ErrPermissionLost
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// get amount by fixed point number
@@ -544,7 +544,7 @@ var (
 				return nil, cost, host.ErrInvalidAmount
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// sub balance of from
@@ -566,7 +566,7 @@ var (
 			cost0 = setBalance(h, tokenSym, from, fbalance, from)
 			cost.AddAssign(cost0)
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// freeze token of to
@@ -611,7 +611,7 @@ var (
 				return nil, cost, host.ErrPermissionLost
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// get amount by fixed point number
@@ -624,7 +624,7 @@ var (
 				return nil, cost, host.ErrInvalidAmount
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// set balance
@@ -645,7 +645,7 @@ var (
 			cost0 = setBalance(h, tokenSym, from, fbalance, from)
 			cost.AddAssign(cost0)
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// set supply
@@ -686,7 +686,7 @@ var (
 				return nil, cost, err
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			balanceStr, cost0 := genAmount(h, tokenSym, balance)
@@ -712,7 +712,7 @@ var (
 				return nil, cost, host.ErrTokenNotExists
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			supply, cost0 := h.MapGet(TokenInfoMapPrefix+tokenSym, SupplyMapField)

--- a/vm/native/token721.go
+++ b/vm/native/token721.go
@@ -82,7 +82,7 @@ var (
 				return nil, cost, host.ErrPermissionLost
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// check exists
@@ -139,7 +139,7 @@ var (
 			totalSupply, cost0 := h.MapGet(Token721InfoMapPrefix+tokenName, TotalSupplyMapField)
 			cost.AddAssign(cost0)
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// check supply
@@ -155,7 +155,7 @@ var (
 				return nil, cost, host.ErrPermissionLost
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			// set supply, set balance
@@ -216,7 +216,7 @@ var (
 				return nil, cost, host.ErrPermissionLost
 			}
 			if !CheckCost(h, cost) {
-				return nil, cost, host.ErrGasLimitExceeded
+				return nil, cost, host.ErrOutOfGas
 			}
 
 			tmp, cost0 := h.MapGet(Token721InfoMapPrefix+tokenName, tokenID)

--- a/vm/utils.go
+++ b/vm/utils.go
@@ -2,6 +2,8 @@ package vm
 
 import (
 	"errors"
+	"fmt"
+	"github.com/iost-official/go-iost/vm/native"
 	"strings"
 
 	"github.com/iost-official/go-iost/account"
@@ -66,6 +68,42 @@ func CheckAmountLimit(db database.IMultiValue, t *tx.Tx) error {
 		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// CheckTxGasLimitValid ...
+func CheckTxGasLimitValid(t *tx.Tx, currentGas *common.Fixed, dbVisitor *database.Visitor) (err error) {
+	gasLimit := &common.Fixed{Value: t.GasLimit, Decimal: 2}
+	if !currentGas.LessThan(gasLimit) {
+		return nil
+	}
+	defaultErr := fmt.Errorf("gas not enough: user %v has %v < %v", t.Publisher, currentGas.ToString(), gasLimit.ToString())
+	if !(len(t.Actions) == 1 && t.Actions[0].Contract == native.GasContractName && t.Actions[0].ActionName == "pledge") {
+		return defaultErr
+	}
+	// user is trying to pledge for gas without initial gas
+	args, err := UnmarshalArgs(dbVisitor.Contract(native.GasContractName).ABI("pledge"), t.Actions[0].Data)
+	if err != nil {
+		return fmt.Errorf("invalid gas pledge args %v %v", err, t.Actions[0].Data)
+	}
+	if !(args[0] == t.Publisher && args[1] == t.Publisher) {
+		return defaultErr
+	}
+	balance := dbVisitor.TokenBalanceFixed("iost", t.Publisher)
+	pledgeAmount, err := common.NewFixed(args[2].(string), 8)
+	if err != nil {
+		return fmt.Errorf("invalid gas pledge amount %v %v", err, args[2].(string))
+	}
+	if pledgeAmount.LessThan(native.GasMinPledgeOfUser) {
+		return fmt.Errorf("invalid gas pledge amount %v %v", err, args[2].(string))
+	}
+	if balance.LessThan(pledgeAmount) {
+		return fmt.Errorf("iost token amount not enough for pledgement %v < %v", balance.ToString(), pledgeAmount.ToString())
+	}
+	if currentGas.Add(pledgeAmount.Multiply(native.GasImmediateReward)).LessThan(gasLimit) {
+		return fmt.Errorf("gas not enough even if considering the new gas pledgement %v + %v < %v",
+			currentGas.ToString(), pledgeAmount.Multiply(native.GasImmediateReward).ToString(), gasLimit.ToString())
 	}
 	return nil
 }


### PR DESCRIPTION
* user can pledge for gas without initial gas. The tx can only contain one action, because otherwise if the second action fails, the user will pay neither IOST nor gas (because of the rolling back).
* add some file permission protection in iwallet 
* ram increases per 10min