### PR TITLE
Fix typo PENDIND to PENDING

### DIFF
--- a/rpc/api_service.go
+++ b/rpc/api_service.go
@@ -111,7 +111,7 @@ func (as *APIService) GetChainInfo(context.Context, *rpcpb.EmptyRequest) (*rpcpb
 // GetTxByHash returns the transaction corresponding to the given hash.
 func (as *APIService) GetTxByHash(ctx context.Context, req *rpcpb.TxHashRequest) (*rpcpb.TransactionResponse, error) {
 	txHashBytes := common.Base58Decode(req.GetHash())
-	status := rpcpb.TransactionResponse_PENDIND
+	status := rpcpb.TransactionResponse_PENDING
 	var (
 		t         *tx.Tx
 		txReceipt *tx.TxReceipt
@@ -153,7 +153,7 @@ func (as *APIService) GetBlockByHash(ctx context.Context, req *rpcpb.GetBlockByH
 		blk *block.Block
 		err error
 	)
-	status := rpcpb.BlockResponse_PENDIND
+	status := rpcpb.BlockResponse_PENDING
 	blk, err = as.bc.GetBlockByHash(hashBytes)
 	if err != nil {
 		status = rpcpb.BlockResponse_IRREVERSIBLE
@@ -175,7 +175,7 @@ func (as *APIService) GetBlockByNumber(ctx context.Context, req *rpcpb.GetBlockB
 		blk *block.Block
 		err error
 	)
-	status := rpcpb.BlockResponse_PENDIND
+	status := rpcpb.BlockResponse_PENDING
 	blk, err = as.bc.GetBlockByNumber(number)
 	if err != nil {
 		status = rpcpb.BlockResponse_IRREVERSIBLE

--- a/rpc/mock_rpc/mock_server.go
+++ b/rpc/mock_rpc/mock_server.go
@@ -55,7 +55,7 @@ func newMockAPI() rpcpb.ApiServiceServer {
 	}, nil)
 
 	api.EXPECT().GetTxByHash(gomock.Any(), gomock.Any()).AnyTimes().Return(&rpcpb.TransactionResponse{
-		Status: rpcpb.TransactionResponse_PENDIND,
+		Status: rpcpb.TransactionResponse_PENDING,
 		Transaction: &rpcpb.Transaction{
 			Hash:       "xxxxx",
 			Time:       999,
@@ -103,7 +103,7 @@ func newMockAPI() rpcpb.ApiServiceServer {
 	}, nil)
 
 	api.EXPECT().GetBlockByHash(gomock.Any(), gomock.Any()).AnyTimes().Return(&rpcpb.BlockResponse{
-		Status: rpcpb.BlockResponse_PENDIND,
+		Status: rpcpb.BlockResponse_PENDING,
 		Block: &rpcpb.Block{
 			Hash:                "hhh",
 			Version:             1,
@@ -157,7 +157,7 @@ func newMockAPI() rpcpb.ApiServiceServer {
 	}, nil)
 
 	api.EXPECT().GetBlockByNumber(gomock.Any(), gomock.Any()).AnyTimes().Return(&rpcpb.BlockResponse{
-		Status: rpcpb.BlockResponse_PENDIND,
+		Status: rpcpb.BlockResponse_PENDING,
 		Block: &rpcpb.Block{
 			Hash:                "hhh",
 			Version:             1,

--- a/rpc/pb/rpc.pb.go
+++ b/rpc/pb/rpc.pb.go
@@ -84,7 +84,7 @@ type TransactionResponse_Status int32
 
 const (
 	// pending in transaction pool
-	TransactionResponse_PENDIND TransactionResponse_Status = 0
+	TransactionResponse_PENDING TransactionResponse_Status = 0
 	// packed in a block that has not been confirmed
 	TransactionResponse_PACKED TransactionResponse_Status = 1
 	// packed in a block that is irreversible
@@ -92,13 +92,13 @@ const (
 )
 
 var TransactionResponse_Status_name = map[int32]string{
-	0: "PENDIND",
+	0: "PENDING",
 	1: "PACKED",
 	2: "IRREVERSIBLE",
 }
 
 var TransactionResponse_Status_value = map[string]int32{
-	"PENDIND":      0,
+	"PENDING":      0,
 	"PACKED":       1,
 	"IRREVERSIBLE": 2,
 }
@@ -148,18 +148,18 @@ type BlockResponse_Status int32
 
 const (
 	// pending in block cache
-	BlockResponse_PENDIND BlockResponse_Status = 0
+	BlockResponse_PENDING BlockResponse_Status = 0
 	// irreversible
 	BlockResponse_IRREVERSIBLE BlockResponse_Status = 1
 )
 
 var BlockResponse_Status_name = map[int32]string{
-	0: "PENDIND",
+	0: "PENDING",
 	1: "IRREVERSIBLE",
 }
 
 var BlockResponse_Status_value = map[string]int32{
-	"PENDIND":      0,
+	"PENDING":      0,
 	"IRREVERSIBLE": 1,
 }
 
@@ -918,7 +918,7 @@ func (m *TransactionResponse) GetStatus() TransactionResponse_Status {
 	if m != nil {
 		return m.Status
 	}
-	return TransactionResponse_PENDIND
+	return TransactionResponse_PENDING
 }
 
 func (m *TransactionResponse) GetTransaction() *Transaction {
@@ -1356,7 +1356,7 @@ func (m *BlockResponse) GetStatus() BlockResponse_Status {
 	if m != nil {
 		return m.Status
 	}
-	return BlockResponse_PENDIND
+	return BlockResponse_PENDING
 }
 
 func (m *BlockResponse) GetBlock() *Block {

--- a/rpc/pb/rpc.proto
+++ b/rpc/pb/rpc.proto
@@ -282,7 +282,7 @@ message TransactionResponse {
     // The enumeration defines transaction status.
     enum Status {
         // pending in transaction pool
-        PENDIND = 0;
+        PENDING = 0;
         // packed in a block that has not been confirmed
         PACKED = 1;
         // packed in a block that is irreversible
@@ -384,7 +384,7 @@ message BlockResponse {
     // The enumeration defines block status.
     enum Status {
         // pending in block cache
-        PENDIND = 0;
+        PENDING = 0;
         // irreversible
         IRREVERSIBLE = 1;
     }

--- a/rpc/pb/rpc.swagger.json
+++ b/rpc/pb/rpc.swagger.json
@@ -938,11 +938,11 @@
     "rpcpbBlockResponseStatus": {
       "type": "string",
       "enum": [
-        "PENDIND",
+        "PENDING",
         "IRREVERSIBLE"
       ],
-      "default": "PENDIND",
-      "description": "The enumeration defines block status.\n\n - PENDIND: pending in block cache\n - IRREVERSIBLE: irreversible"
+      "default": "PENDING",
+      "description": "The enumeration defines block status.\n\n - PENDING: pending in block cache\n - IRREVERSIBLE: irreversible"
     },
     "rpcpbChainInfoResponse": {
       "type": "object",
@@ -1449,12 +1449,12 @@
     "rpcpbTransactionResponseStatus": {
       "type": "string",
       "enum": [
-        "PENDIND",
+        "PENDING",
         "PACKED",
         "IRREVERSIBLE"
       ],
-      "default": "PENDIND",
-      "description": "The enumeration defines transaction status.\n\n - PENDIND: pending in transaction pool\n - PACKED: packed in a block that has not been confirmed\n - IRREVERSIBLE: packed in a block that is irreversible"
+      "default": "PENDING",
+      "description": "The enumeration defines transaction status.\n\n - PENDING: pending in transaction pool\n - PACKED: packed in a block that has not been confirmed\n - IRREVERSIBLE: packed in a block that is irreversible"
     },
     "rpcpbTxReceipt": {
       "type": "object",


### PR DESCRIPTION
There is a typo 'PENDIND'. According to the description for 'PENDIND', I'm sure it should be fixed to "PENDING".

Please check.