### PR TITLE
Update benchmark under itest

### DIFF
--- a/itest/client.go
+++ b/itest/client.go
@@ -112,7 +112,7 @@ func (c *Client) GetAccount(name string) (*Account, error) {
 }
 
 // SendTransaction will send transaction to blockchain
-func (c *Client) SendTransaction(transaction *Transaction) (string, error) {
+func (c *Client) SendTransaction(transaction *Transaction, check bool) (string, error) {
 	grpc, err := c.getGRPC()
 	if err != nil {
 		return "", err
@@ -125,13 +125,15 @@ func (c *Client) SendTransaction(transaction *Transaction) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	ilog.Debugf("transaction size: %vbytes", len(transaction.ToBytes(tx.Full)))
+	if check {
+		ilog.Debugf("transaction size: %vbytes", len(transaction.ToBytes(tx.Full)))
 
-	ilog.Debugf("Check transaction receipt for %v...", resp.GetHash())
-	if err := c.checkTransaction(resp.GetHash()); err != nil {
-		return "", err
+		ilog.Debugf("Check transaction receipt for %v...", resp.GetHash())
+		if err := c.checkTransaction(resp.GetHash()); err != nil {
+			return "", err
+		}
+		ilog.Debugf("Check transaction receipt for %v successful!", resp.GetHash())
 	}
-	ilog.Debugf("Check transaction receipt for %v successful!", resp.GetHash())
 
 	return resp.GetHash(), nil
 }
@@ -194,7 +196,7 @@ func (c *Client) CreateAccount(creator *Account, name string, key *Key) (*Accoun
 	}
 
 	ilog.Debugf("Sending create account transaction for %v...", name)
-	if _, err := c.SendTransaction(st); err != nil {
+	if _, err := c.SendTransaction(st, true); err != nil {
 		return nil, err
 	}
 	ilog.Debugf("Sended create account transaction for %v!", name)
@@ -224,7 +226,7 @@ func (c *Client) ContractTransfer(cid string, sender, recipient *Account, amount
 		return err
 	}
 
-	if _, err := c.SendTransaction(st); err != nil {
+	if _, err := c.SendTransaction(st, true); err != nil {
 		return err
 	}
 
@@ -251,7 +253,7 @@ func (c *Client) CallAction(sender *Account, contractName, actionName string, ar
 		return "", err
 	}
 
-	hash, err := c.SendTransaction(st)
+	hash, err := c.SendTransaction(st, true)
 	if err != nil {
 		return "", err
 	}
@@ -272,7 +274,7 @@ func (c *Client) Vote(sender *Account, voteID, recipient, amount string) error {
 }
 
 // Transfer will transfer token by sending transaction
-func (c *Client) Transfer(sender, recipient *Account, token, amount string) error {
+func (c *Client) Transfer(sender, recipient *Account, token, amount string, check bool) error {
 	action := tx.NewAction(
 		"token.iost",
 		"transfer",
@@ -287,7 +289,7 @@ func (c *Client) Transfer(sender, recipient *Account, token, amount string) erro
 		return err
 	}
 
-	if _, err := c.SendTransaction(st); err != nil {
+	if _, err := c.SendTransaction(st, check); err != nil {
 		return err
 	}
 
@@ -310,7 +312,7 @@ func (c *Client) SetContract(creator *Account, contract *Contract) (string, erro
 		return "", err
 	}
 
-	hash, err := c.SendTransaction(st)
+	hash, err := c.SendTransaction(st, true)
 	if err != nil {
 		return "", err
 	}

--- a/itest/command/run/account_case.go
+++ b/itest/command/run/account_case.go
@@ -10,28 +10,13 @@ var AccountCaseCommand = cli.Command{
 	Name:      "account_case",
 	ShortName: "a_case",
 	Usage:     "run account test case",
-	Flags:     AccountCaseFlags,
 	Action:    AccountCaseAction,
-}
-
-// AccountCaseFlags is the flags of account test case
-var AccountCaseFlags = []cli.Flag{
-	cli.IntFlag{
-		Name:  "number, n",
-		Value: 10,
-		Usage: "number of account",
-	},
-	cli.StringFlag{
-		Name:  "output, o",
-		Value: "accounts.json",
-		Usage: "output of account information",
-	},
 }
 
 // AccountCaseAction is the action of account test case
 var AccountCaseAction = func(c *cli.Context) error {
-	anum := c.Int("number")
-	output := c.String("output")
+	anum := c.GlobalInt("anum")
+	output := c.GlobalString("account")
 	keysfile := c.GlobalString("keys")
 	configfile := c.GlobalString("config")
 

--- a/itest/command/run/benchmark.go
+++ b/itest/command/run/benchmark.go
@@ -70,7 +70,7 @@ var BenchmarkAction = func(c *cli.Context) error {
 		case <-ticker.C:
 		}
 
-		counter += 1
+		counter++
 		total += num
 		if counter == 10 {
 			ilog.Warnf("Current tps: %v", float64(total)/time.Now().Sub(startTime).Seconds())
@@ -79,5 +79,4 @@ var BenchmarkAction = func(c *cli.Context) error {
 			startTime = time.Now()
 		}
 	}
-	return nil
 }

--- a/itest/command/run/benchmark.go
+++ b/itest/command/run/benchmark.go
@@ -1,31 +1,83 @@
 package run
 
 import (
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/iost-official/go-iost/ilog"
 	"github.com/iost-official/go-iost/itest"
 	"github.com/urfave/cli"
 )
 
-// BenchmarkCommand is the command of benchmark
+// BenchmarkCommand is the subcommand for benchmark.
 var BenchmarkCommand = cli.Command{
 	Name:      "benchmark",
 	ShortName: "bench",
-	Usage:     "run benchmark test by data",
+	Usage:     "Run benchmark by given tps",
+	Flags:     BenchmarkFlags,
 	Action:    BenchmarkAction,
 }
 
-// BenchmarkAction is the action of benchmark
+// BenchmarkFlags is the list of flags for benchmark.
+var BenchmarkFlags = []cli.Flag{
+	cli.IntFlag{
+		Name:  "tps",
+		Value: 100,
+		Usage: "The expected ratio of transactions per second",
+	},
+}
+
+// BenchmarkAction is the action of benchmark.
 var BenchmarkAction = func(c *cli.Context) error {
-	dfile := "benchmark.json"
-
-	r := itest.NewRunner(dfile)
-	if err := r.Run(); err != nil {
+	keyFile := c.GlobalString("keys")
+	configFile := c.GlobalString("config")
+	it, err := itest.Load(keyFile, configFile)
+	if err != nil {
 		return err
 	}
 
-	<-r.Done()
-	if err := r.Err(); err != nil {
-		return err
+	accountFile := c.GlobalString("account")
+	accounts, err := itest.LoadAccounts(accountFile)
+	if err != nil {
+		if err := AccountCaseAction(c); err != nil {
+			return err
+		}
+		if accounts, err = itest.LoadAccounts(accountFile); err != nil {
+			return err
+		}
 	}
 
+	tps := c.Int("tps")
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+
+	counter := 0
+	total := 0
+	startTime := time.Now()
+
+	ticker := time.NewTicker(time.Second)
+	for {
+		num, err := it.TransferN(tps, accounts, false)
+		if err != nil {
+			ilog.Infoln(err)
+		}
+		select {
+		case <-sig:
+			return itest.DumpAccounts(accounts, accountFile)
+		case <-ticker.C:
+		}
+
+		counter += 1
+		total += num
+		if counter == 10 {
+			ilog.Warnf("Current tps: %v", float64(total)/time.Now().Sub(startTime).Seconds())
+			counter = 0
+			total = 0
+			startTime = time.Now()
+		}
+	}
 	return nil
 }

--- a/itest/command/run/run.go
+++ b/itest/command/run/run.go
@@ -41,4 +41,14 @@ var Flags = []cli.Flag{
 		Value: "",
 		Usage: "Load contract abi from `FILE`",
 	},
+	cli.StringFlag{
+		Name:  "account, a",
+		Value: "accounts.json",
+		Usage: "The account file that itest would load from if exists",
+	},
+	cli.IntFlag{
+		Name:  "anum",
+		Value: 100,
+		Usage: "The number of accounts to generated if no given account file",
+	},
 }

--- a/itest/command/run/transfer_case.go
+++ b/itest/command/run/transfer_case.go
@@ -22,11 +22,6 @@ var TransferCaseFlags = []cli.Flag{
 		Usage: "number of transaction",
 	},
 	cli.StringFlag{
-		Name:  "account, a",
-		Value: "accounts.json",
-		Usage: "load accounts from `FILE`",
-	},
-	cli.StringFlag{
 		Name:  "output, o",
 		Value: "accounts.json",
 		Usage: "output of account information",
@@ -35,7 +30,7 @@ var TransferCaseFlags = []cli.Flag{
 
 // TransferCaseAction is the action of transfer test case
 var TransferCaseAction = func(c *cli.Context) error {
-	afile := c.String("account")
+	afile := c.GlobalString("account")
 	output := c.String("output")
 	tnum := c.Int("number")
 	keysfile := c.GlobalString("keys")
@@ -51,7 +46,7 @@ var TransferCaseAction = func(c *cli.Context) error {
 		return err
 	}
 
-	if err := it.TransferN(tnum, accounts); err != nil {
+	if _, err := it.TransferN(tnum, accounts, true); err != nil {
 		return err
 	}
 

--- a/itest/itest.go
+++ b/itest/itest.go
@@ -223,7 +223,7 @@ func (t *ITest) TransferN(num int, accounts []*Account, check bool) (successNum 
 				firstErr = fmt.Errorf("Failed to send transfer transactions: %v", value)
 			}
 		default:
-			successNum += 1
+			successNum++
 		}
 	}
 

--- a/itest/itest.go
+++ b/itest/itest.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"strconv"
 
 	"github.com/iost-official/go-iost/ilog"
 )
@@ -184,8 +185,8 @@ func (t *ITest) VoteN(num, pnum int, accounts []*Account) error {
 }
 
 // TransferN will send n transfer transaction concurrently
-func (t *ITest) TransferN(num int, accounts []*Account) error {
-	ilog.Infof("Send %v transfer transaction...", num)
+func (t *ITest) TransferN(num int, accounts []*Account, check bool) (successNum int, firstErr error) {
+	ilog.Infof("Sending %v transfer transactions...", num)
 
 	res := make(chan interface{})
 	go func() {
@@ -195,14 +196,22 @@ func (t *ITest) TransferN(num int, accounts []*Account) error {
 			go func(res chan interface{}) {
 				defer sem.release()
 				A := accounts[rand.Intn(len(accounts))]
+				balance, _ := strconv.ParseFloat(A.balance, 64)
+				for balance < 1 {
+					A = accounts[rand.Intn(len(accounts))]
+					balance, _ = strconv.ParseFloat(A.balance, 64)
+				}
 				B := accounts[rand.Intn(len(accounts))]
-				amount := float64(rand.Int63n(10000)+1) / 100
+				amount := float64(rand.Int63n(int64(math.Min(10000, balance*100)))+1) / 100
 
-				A.AddBalance(-amount)
-				B.AddBalance(amount)
 				ilog.Debugf("Transfer %v -> %v, amount: %v", A.ID, B.ID, fmt.Sprintf("%0.8f", amount))
+				err := t.Transfer(A, B, "iost", fmt.Sprintf("%0.8f", amount), check)
 
-				res <- t.Transfer(A, B, "iost", fmt.Sprintf("%0.8f", amount))
+				if err == nil {
+					A.AddBalance(-amount)
+					B.AddBalance(amount)
+				}
+				res <- err
 			}(res)
 		}
 	}()
@@ -210,14 +219,16 @@ func (t *ITest) TransferN(num int, accounts []*Account) error {
 	for i := 0; i < num; i++ {
 		switch value := (<-res).(type) {
 		case error:
-			return fmt.Errorf("send transfer transaction failed: %v", value)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("Failed to send transfer transactions: %v", value)
+			}
 		default:
+			successNum += 1
 		}
 	}
 
-	ilog.Infof("Send %v transfer transaction successful!", num)
-
-	return nil
+	ilog.Infof("Sent %v/%v transfer transactions", successNum, num)
+	return
 }
 
 // ContractTransferN will send n contract transfer transaction concurrently
@@ -348,11 +359,11 @@ func (t *ITest) CallActionWithRandClient(sender *Account, contractName, actionNa
 }
 
 // Transfer will transfer token from sender to recipient
-func (t *ITest) Transfer(sender, recipient *Account, token, amount string) error {
+func (t *ITest) Transfer(sender, recipient *Account, token, amount string, check bool) error {
 	cIndex := rand.Intn(len(t.clients))
 	client := t.clients[cIndex]
 
-	err := client.Transfer(sender, recipient, token, amount)
+	err := client.Transfer(sender, recipient, token, amount, check)
 	if err != nil {
 		return err
 	}
@@ -402,11 +413,11 @@ func (t *ITest) GetAccount(name string) (*Account, error) {
 }
 
 // SendTransaction will send transaction to blockchain
-func (t *ITest) SendTransaction(transaction *Transaction) (string, error) {
+func (t *ITest) SendTransaction(transaction *Transaction, check bool) (string, error) {
 	cIndex := rand.Intn(len(t.clients))
 	client := t.clients[cIndex]
 
-	hash, err := client.SendTransaction(transaction)
+	hash, err := client.SendTransaction(transaction, check)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Benchmark would send transfer transactions without checking receipts by given tps.

Result of `./target/itest -l warn run bench --tps 1000` as following:
![image](https://user-images.githubusercontent.com/45415822/50721153-95563e80-10f5-11e9-8466-648e7b311f71.png)
![image](https://user-images.githubusercontent.com/45415822/50721155-98e9c580-10f5-11e9-9401-3c3e9a19cc93.png)
![image](https://user-images.githubusercontent.com/45415822/50721156-9ab38900-10f5-11e9-93bf-cbdc8de8d8f3.png)

TODO: Figure out the problem inside metrics later.