### PR TITLE
Update help msgs

### DIFF
--- a/iwallet/balance.go
+++ b/iwallet/balance.go
@@ -22,22 +22,21 @@ import (
 
 // accountInfoCmd represents the balance command.
 var accountInfoCmd = &cobra.Command{
-	Use:   "balance",
+	Use:   "balance accoutID",
 	Short: "Check the information of a specified account",
-	Long:  `Check the information of a specified account, must followed by an account ID`,
+	Long:  `Check the information of a specified account`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			return fmt.Errorf("Please enter the account ID")
+			cmd.Usage()
+			return fmt.Errorf("please enter the account ID")
 		}
-		// Do some checks for arg[0] here.
 		return nil
 	},
-	RunE: func(cmd *cobra.Command, args []string) (err error) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		id := args[0]
 		info, err := sdk.getAccountInfo(id)
 		if err != nil {
-			fmt.Println(err)
-			return
+			return err
 		}
 		fmt.Println(marshalTextString(info))
 		return nil

--- a/iwallet/block.go
+++ b/iwallet/block.go
@@ -25,41 +25,41 @@ import (
 var method string
 var complete bool
 
+var methodMap = map[string]func(string) (*rpcpb.BlockResponse, error){
+	"num": func(arg string) (*rpcpb.BlockResponse, error) {
+		num, err := strconv.ParseInt(arg, 10, 64)
+		if err != nil {
+			err = fmt.Errorf("invalid block number: %v", err)
+			return nil, err
+		}
+		return sdk.getGetBlockByNum(num, complete)
+	},
+	"hash": func(arg string) (*rpcpb.BlockResponse, error) {
+		return sdk.getGetBlockByHash(arg, complete)
+	},
+}
+
 // blockCmd represents the block command.
 var blockCmd = &cobra.Command{
-	Use:   "block",
+	Use:   "block blockNum|blockHash",
 	Short: "Print block info",
 	Long:  `Print block info by block number or hash`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			return fmt.Errorf("Please enter the block number or hash")
+			cmd.Usage()
+			return fmt.Errorf("please enter the block number or hash")
+		}
+		_, ok := methodMap[method]
+		if !ok {
+			cmd.Usage()
+			return fmt.Errorf("wrong method: %v", method)
 		}
 		return nil
 	},
-	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		var blockInfo *rpcpb.BlockResponse
-		var num int64
-		switch method {
-		case "num":
-			num, err = strconv.ParseInt(args[0], 10, 64)
-			if err != nil {
-				fmt.Printf("invalid block number %v\n", err)
-				return
-			}
-			blockInfo, err = sdk.getGetBlockByNum(num, complete)
-			if err != nil {
-				fmt.Printf(err.Error())
-				return
-			}
-		case "hash":
-			blockInfo, err = sdk.getGetBlockByHash(args[0], complete)
-			if err != nil {
-				fmt.Printf(err.Error())
-				return
-			}
-		default:
-			fmt.Printf("Wrong method '%v'. Supported methods: 'num', 'hash'\n", method)
-			return
+	RunE: func(cmd *cobra.Command, args []string) error {
+		blockInfo, err := methodMap[method](args[0])
+		if err != nil {
+			return err
 		}
 		fmt.Println(marshalTextString(blockInfo))
 		return nil
@@ -68,6 +68,6 @@ var blockCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(blockCmd)
-	blockCmd.Flags().StringVarP(&method, "method", "m", "num", "find by block num (set as 'num') or hash (set as 'hash')")
+	blockCmd.Flags().StringVarP(&method, "method", "m", "num", `find by block num (set as "num") or hash (set as "hash")`)
 	blockCmd.Flags().BoolVarP(&complete, "complete", "c", false, "indicate whether to fetch all the transactions in the block or not")
 }

--- a/iwallet/compile.go
+++ b/iwallet/compile.go
@@ -47,17 +47,18 @@ func generateABI(codePath string) (string, error) {
 
 // compileCmd represents the compile command.
 var compileCmd = &cobra.Command{
-	Use:   "compile",
-	Short: "Generate contract abi",
-	Long: `Generate abi from contract javascript code
-	Example:
-		iwallet compile ./example.js
-	`,
-
-	RunE: func(cmd *cobra.Command, args []string) (err error) {
+	Use:     "compile codePath",
+	Short:   "Generate contract abi",
+	Long:    `Generate abi from contract javascript code`,
+	Example: `  iwallet compile ./example.js`,
+	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			return fmt.Errorf("source code file not given")
+			cmd.Usage()
+			return fmt.Errorf("please enter the code path")
 		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
 		codePath := args[0]
 		abiPath, err := generateABI(codePath)
 		if err != nil {

--- a/iwallet/key.go
+++ b/iwallet/key.go
@@ -34,11 +34,10 @@ var keyCmd = &cobra.Command{
 	Use:   "key",
 	Short: "Create a key pair",
 	Long:  `Create a key pair`,
-	RunE: func(cmd *cobra.Command, args []string) (err error) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		n, err := account.NewKeyPair(nil, sdk.GetSignAlgo())
 		if err != nil {
-			fmt.Printf("NewKeyPair error: %v\n", err)
-			return
+			return fmt.Errorf("failed to new key pair: %v", err)
 		}
 
 		var k key
@@ -48,8 +47,7 @@ var keyCmd = &cobra.Command{
 
 		ret, err := json.MarshalIndent(k, "", "    ")
 		if err != nil {
-			fmt.Printf("MarshalIndent error: %v\n", err)
-			return
+			return fmt.Errorf("failed to marshal: %v", err)
 		}
 		fmt.Println(string(ret))
 		return nil

--- a/iwallet/receipt.go
+++ b/iwallet/receipt.go
@@ -22,18 +22,20 @@ import (
 
 // receiptCmd represents the receipt command.
 var receiptCmd = &cobra.Command{
-	Use:   "receipt",
+	Use:   "receipt transactionHash",
 	Short: "Find receipt",
 	Long:  `Find receipt by transaction hash`,
-	RunE: func(cmd *cobra.Command, args []string) (err error) {
+	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			fmt.Println("Please enter the transaction hash")
-			return
+			cmd.Usage()
+			return fmt.Errorf("please enter the transaction hash")
 		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
 		txReceipt, err := sdk.GetTxReceiptByTxHash(args[0])
 		if err != nil {
-			fmt.Println(err.Error())
-			return
+			return err
 		}
 		fmt.Println(marshalTextString(txReceipt))
 		return nil

--- a/iwallet/sign.go
+++ b/iwallet/sign.go
@@ -30,26 +30,30 @@ var signCmd = &cobra.Command{
 	Use:   "sign",
 	Short: "Sign a tx loaded from given file and save the signature as a binary file",
 	Long:  `Sign a tx loaded from given file (--tx_file) and save the signature as a binary file (--output)`,
-	RunE: func(cmd *cobra.Command, args []string) (err error) {
+	Args: func(cmd *cobra.Command, args []string) error {
 		if outputFile == "" {
+			cmd.Usage()
 			return fmt.Errorf("output file name should be provided with --output flag")
 		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
 		trx := &rpcpb.TransactionRequest{}
-		err = loadProto(txFile, trx)
+		err := loadProto(txFile, trx)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to load transaction file: %v", err)
 		}
 		kp, err := loadKeyPair(signKeyFile, sdk.GetSignAlgo())
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to load key pair: %v", err)
 		}
 		sig := sdk.getSignatureOfTx(trx, kp)
 		err = saveProto(sig, outputFile)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to save signature: %v", err)
 		}
 		fmt.Println("Successfully saved signature as:", outputFile)
-		return
+		return nil
 	},
 }
 

--- a/iwallet/state.go
+++ b/iwallet/state.go
@@ -26,17 +26,15 @@ var stateCmd = &cobra.Command{
 	Use:   "state",
 	Short: "Get blockchain and node state",
 	Long:  `Get blockchain and node state`,
-	RunE: func(cmd *cobra.Command, args []string) (err error) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		n, err := sdk.getNodeInfo()
 		if err != nil {
-			fmt.Println("Cannot get node info:", err)
-			return
+			return fmt.Errorf("cannot get node info: %v", err)
 		}
 		fmt.Print(strings.TrimRight(marshalTextString(n), "}"))
 		c, err := sdk.getChainInfo()
 		if err != nil {
-			fmt.Println("Cannot get chain info:", err)
-			return
+			return fmt.Errorf("cannot get chain info: %v", err)
 		}
 		fmt.Println(strings.Replace(marshalTextString(c), "{\n", "", 1))
 		return nil

--- a/iwallet/transaction.go
+++ b/iwallet/transaction.go
@@ -22,17 +22,20 @@ import (
 
 // transactionCmd represents the transaction command.
 var transactionCmd = &cobra.Command{
-	Use:   "transaction",
+	Use:   "transaction transactionHash",
 	Short: "Find transactions",
 	Long:  `Find transaction by transaction hash`,
-	RunE: func(cmd *cobra.Command, args []string) (err error) {
+	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			fmt.Println(`Error: transaction hash not given`)
-			return
+			cmd.Usage()
+			return fmt.Errorf("please enter the transaction hash")
 		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
 		txRaw, err := sdk.getTxByHash(args[0])
 		if err != nil {
-			fmt.Println(err.Error())
+			return err
 		}
 		fmt.Println(marshalTextString(txRaw))
 		return nil


### PR DESCRIPTION
* Add positional args in use line
* Add examples/aliases
* Move arg checks in Arg func
* Del unnecessary error print in RunE (which will duplicate the error msg in result)
* Better to keep same sentences in msgs

Result:
![image](https://user-images.githubusercontent.com/45415822/51787467-4740d200-21ad-11e9-9603-73d62cd0a6b6.png)

@lispc How about we split the account command to some sub-cmds? How about we rename `tx` command to some stuff like `proto`? Since it is really confusing that we already have a transaction command. But let's keep it in this pr and update in next one anyway.

p.s. the doc of cobra is not complete but the code https://github.com/spf13/cobra/blob/master/command.go is easy to read anyway. :)