### PR TITLE
Remove duplicate check in iwallet/publish.go

### DIFF
--- a/iwallet/publish.go
+++ b/iwallet/publish.go
@@ -62,13 +62,8 @@ var publishCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to create tx: %v", err)
 		}
-		if sdk.checkResult {
-			if err := sdk.checkTransaction(txHash); err != nil {
-				return err
-			}
-			if !update {
-				fmt.Println("The contract id is Contract" + txHash)
-			}
+		if !update {
+			fmt.Println("The contract id is: Contract" + txHash)
 		}
 		return nil
 	},


### PR DESCRIPTION
We already check the transaction receipt inside SendTx.