### PR TITLE
Fix flag setting in iwallet

### DIFF
--- a/iwallet/system_producer.go
+++ b/iwallet/system_producer.go
@@ -17,9 +17,9 @@ package iwallet
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/iost-official/go-iost/sdk"
 
 	"github.com/iost-official/go-iost/rpc/pb"
+	"github.com/iost-official/go-iost/sdk"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
"Execute adds all child commands to the root command and sets flags appropriately." and we should set all flags for SDK inside Execute().

Example of can not set server address like following
![image](https://user-images.githubusercontent.com/45415822/52842247-778ae900-3139-11e9-93c5-a0333507f03d.png)
