### PR TITLE
IB-613 Fix iserver auto-start issue

### DIFF
--- a/script/boot.sh
+++ b/script/boot.sh
@@ -185,7 +185,7 @@ services:
   iserver:
     image: iostio/iost-node:$VERSION
     container_name: iserver
-    restart: on-failure
+    restart: unless-stopped
     ports:
       - "30000-30003:30000-30003"
     volumes:

--- a/script/upgrade.sh
+++ b/script/upgrade.sh
@@ -31,12 +31,19 @@ print_bye() {
     }>&2
 }
 
+update_container_restart_policy() {
+    # IB-613 fix container restart policy
+    sed -i.bak 's/on-failure/unless-stopped/' $PREFIX/docker-compose.yml
+    rm -f $PREFIX/docker-compose.yml.bak
+}
+
 #
 # main
 #
 
 cd $PREFIX
 
+update_container_restart_policy
 docker-compose pull
 docker-compose up -d
 


### PR DESCRIPTION
Change container restart policy in order to auto-restart iServer when restarting docker daemon.
See also [docker official doc at here](https://docs.docker.com/config/containers/start-containers-automatically/).