### PR TITLE
Fix #986: iserver will start though rpc endpoint is already in use.

### DIFF
--- a/cmd/iserver/main.go
+++ b/cmd/iserver/main.go
@@ -95,7 +95,9 @@ func main() {
 	}
 
 	server := iserver.New(conf)
-	server.Start()
+	if err := server.Start(); err != nil {
+		ilog.Fatalf("start iserver failed. err=%v", err)
+	}
 
 	waitExit()
 


### PR DESCRIPTION
#986 