### PR TITLE
Release v3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+##v3.3.1
+Fri Dec 13 11:51:32 CST 2019
+
+- Add ripemd160 hash function to chain api, empowering oncoming atomic swap with BTC and ETH.
+- Optimize memory management.
+
+
 ## v3.3.0
 Fri Sep 20 15:21:41 CST 2019
 

--- a/build/k8s/iserver.yaml
+++ b/build/k8s/iserver.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: iserver
-          image: "iostio/iost-node:3.3.0-$COMMIT"
+          image: "iostio/iost-node:3.3.1-$COMMIT"
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash

--- a/build/k8s/itest.yaml
+++ b/build/k8s/itest.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: itest
-    image: "iostio/iost-node:3.3.0-$COMMIT"
+    image: "iostio/iost-node:3.3.1-$COMMIT"
     imagePullPolicy: "IfNotPresent"
     command: ['/bin/bash', '-c', 'sleep infinity']
     resources:


### PR DESCRIPTION
##v3.3.1
Fri Dec 13 11:51:32 CST 2019

- Add ripemd160 hash function to chain api, empowering oncoming atomic swap with BTC and ETH.
- Optimize memory management.