### PR TITLE
feat: Remove forceUnregister method. 

### DIFF
--- a/config/genesis/contract/vote_producer.js
+++ b/config/genesis/contract/vote_producer.js
@@ -244,21 +244,6 @@ class VoteContract {
         blockchain.receipt(JSON.stringify([account]));
     }
 
-    // force approve remove account from producer list
-    forceUnregister(account) {
-        const admin = storage.get("adminID");
-        this._requireAuth(admin, ADMIN_PERMISSION);
-        if (!storage.mapHas("producerTable", account)) {
-            throw new Error("producer not exists");
-        }
-        const pro = this._mapGet("producerTable", account);
-        // will clear votes and score of the producer on stat
-        pro.status = STATUS_UNAPPLY_APPROVED;
-        this._mapPut("producerTable", account, pro);
-        this._removeFromProducerMap(account, pro);
-        blockchain.receipt(JSON.stringify([account]));
-    }
-
     unregister(account) {
         this._requireAuthList(this._getAccountList(account), VOTE_PERMISSION);
         const pro = this._mapGet("producerTable", account);

--- a/config/genesis/contract/vote_producer.js.abi
+++ b/config/genesis/contract/vote_producer.js.abi
@@ -70,13 +70,6 @@
             "amountLimit": []
         },
         {
-            "name": "forceUnregister",
-            "args": [
-                "string"
-            ],
-            "amountLimit": []
-        },
-        {
             "name": "unregister",
             "args": [
                 "string"


### PR DESCRIPTION
It seems like this method is unnecessary and hurts the decentralization of the network. IOST could replace the top nodes today with a few iwallet commands, and that seems like too much power on a public blockchain. 

Nodes can still deregister then be deactivated after opting in, and nodes that go offline should be removed from the rotation. 